### PR TITLE
AI Services Page Update

### DIFF
--- a/src/components/IconTextBoxFlex.js
+++ b/src/components/IconTextBoxFlex.js
@@ -100,32 +100,32 @@ const IconTextBoxFlex = (props) => {
     }
 
     return(
-            <div className={wrapperClasses} key={`iconTextBoxFlex-item${Math.random()}`}>
-                <div ref={iconElement}>
-                    {component}
-                </div>
-                <div className={'flex-col flex flex-1'}>
-                    {content.heading && 
-                        <div className={`mb-4`}>
-                            <p ref={ref}
-                                style={{marginTop: customTop, marginBottom: customBottom, marginLeft: '24px', textTransform: customCase}}
-                                className={ `${headingfont} block items-center ${props.color} w-full` }>
-                                { content.heading }
-                            </p>
-                        </div>
-                    }
-                    {content.body && 
-                        <div className={ `${marginClasses}`}>
-                            <p dangerouslySetInnerHTML={{__html: Parser(content.body)}} className={ `${theme.text['FOOTER']}  ${props.color}` }></p>
-                        </div>
-                    }
-                    {content.link && 
-                        <div className={ marginClasses + `mt-4`}>
-                            <Link link={content.link} classes={`${theme.text_links.BASE_STYLING} ${theme.text_links.STD} ${theme.text_links['FWD_BASE']} ${theme.text_links['ARW_FWD_GREEN']} ${theme.text_links.HOVER_ARW_FWD_WHITE} ${theme.text_links.HOVER_WHITE} text-[#A9CF38]`} />
-                        </div>
-                    }
-                </div>
+        <div className={wrapperClasses} key={`iconTextBoxFlex-item${Math.random()}`}>
+            <div ref={iconElement}>
+                {component}
             </div>
+            <div className={'flex-col flex flex-1'}>
+                {content.heading && 
+                    <div className={`mb-4`}>
+                        <p ref={ref}
+                            style={{marginTop: customTop, marginBottom: customBottom, marginLeft: '24px', textTransform: customCase}}
+                            className={ `${headingfont} block items-center ${props.color} w-full` }>
+                            { content.heading }
+                        </p>
+                    </div>
+                }
+                {content.body && 
+                    <div className={ `${marginClasses}`}>
+                        <p dangerouslySetInnerHTML={{__html: Parser(content.body)}} className={ `${theme.text['FOOTER']}  ${props.color}` }></p>
+                    </div>
+                }
+                {content.link && 
+                    <div className={ marginClasses + `mt-4`}>
+                        <Link link={content.link} classes={`${theme.text_links.BASE_STYLING} ${theme.text_links.STD} ${theme.text_links['FWD_BASE']} ${theme.text_links['ARW_FWD_GREEN']} ${theme.text_links.HOVER_ARW_FWD_WHITE} ${theme.text_links.HOVER_WHITE} text-[#A9CF38]`} />
+                    </div>
+                }
+            </div>
+        </div>
     )
 }
 

--- a/src/components/IconTextBoxStack.js
+++ b/src/components/IconTextBoxStack.js
@@ -9,7 +9,7 @@ const IconTextBoxStack = (props) => {
     const content   = props.content;
     const iconType  = props.iconType;
     
-    let component   =  <span className={'block w-[138px] ml-auto mr-auto md:ml-0 md:mr-0 border-t-2 border-t-rm-green mb-7'}></span>;
+    let component   = <span className={'block w-[138px] ml-auto mr-auto md:ml-0 md:mr-0 border-t-2 border-t-rm-green mb-7'}></span>;
 
     const body      = content.body && Parser(content.body);
     const heading   = content.heading && Parser(content.heading);
@@ -26,6 +26,7 @@ const IconTextBoxStack = (props) => {
             {image}
         </div> 
     } 
+
     if (iconType === 'number') {
         component = 
         <div className={"mb-5 text-center md:text-left lg:mx-0"}>
@@ -44,18 +45,19 @@ const IconTextBoxStack = (props) => {
             </div> 
         </div>
     }
-            return (
-            <div className={'py-4'} key={`iconTextBoxFlex-item${Math.random()}`}>
-                {component}
-                <h5 dangerouslySetInnerHTML={{__html: heading}} className={theme.text.H5 + ` text-center md:text-left ${props.color}`}></h5>        
-                <p dangerouslySetInnerHTML={{__html: body}} className={ theme.text.P_STD + `text-center md:text-left mt-4 ${props.color}`}></p>
-                {content.link && 
-                    <div className={`mt-4`}>
-                        <Link link={content.link} classes={`${theme.text_links.BASE_STYLING} ${theme.text_links.STD} ${theme.text_links['FWD_BASE']} ${theme.text_links['ARW_FWD_GREEN']} ${theme.text_links.HOVER_ARW_FWD_WHITE} ${theme.text_links.HOVER_WHITE} text-[#A9CF38]`} />
-                    </div>
-                }
-            </div>
-            )
+
+    return (
+        <div className={'py-4'} key={`iconTextBoxFlex-item${Math.random()}`}>
+            {component}
+            <h5 dangerouslySetInnerHTML={{__html: heading}} className={theme.text.H5 + ` text-center md:text-left ${props.color}`}></h5>        
+            <p dangerouslySetInnerHTML={{__html: body}} className={ theme.text.P_STD + `text-center md:text-left mt-4 ${props.color}`}></p>
+            {content.link && 
+                <div className={`mt-4`}>
+                    <Link link={content.link} classes={`${theme.text_links.BASE_STYLING} ${theme.text_links.STD} ${theme.text_links['FWD_BASE']} ${theme.text_links['ARW_FWD_GREEN']} ${theme.text_links.HOVER_ARW_FWD_WHITE} ${theme.text_links.HOVER_WHITE} text-[#A9CF38]`} />
+                </div>
+            }
+        </div>
+    )
 }
 
 export default IconTextBoxStack;

--- a/src/components/global/Buttons.js
+++ b/src/components/global/Buttons.js
@@ -34,7 +34,7 @@ const Buttons = (props) => {
 
     let buttonClass   = style + baseColor + background;
 
-    //Transparent background with white hover state 
+    //Transparent background with white hover state
     if (baseColor.toUpperCase() === 'TRANSPARENT') {
         buttonClass = 'GHOST_TRANSPARENT_WHITE';
     }

--- a/src/components/global/Parser.js
+++ b/src/components/global/Parser.js
@@ -80,7 +80,12 @@ const tagList = [
     {
         tag:`[h5]`,
         replace:`<span style="display:block;" class="${theme.text.H5}">`
-    }
+    },
+    {
+        tag:`[basicSans]`,
+        replace:`<span class="font-basic-sans">`
+    },
+    
 ];
 
 const tagListBlog = [

--- a/src/components/global/Parser.js
+++ b/src/components/global/Parser.js
@@ -30,6 +30,10 @@ const tagList = [
         replace: `<span class="text-rm-green font-semibold">`
     },
     {
+        tag: `[black]`,
+        replace: `<span class="text-rm-black">`
+    },
+    {
         tag: `[lightBlue]`,
         replace: `<span class="text-[#A4FAFF]">`
     },
@@ -53,6 +57,14 @@ const tagList = [
         tag: `[i]`,
         replace: `<span style="font-style:italic;">`
     }, 
+    {
+        tag:`[H1_STD]`,
+        replace:`<span style="display:block;" class="${theme.text.H1_STD}">`
+    },
+    {
+        tag:`[H1_LTE]`,
+        replace:`<span style="display:block;" class="${theme.text.H1_LTE}">`
+    },
     {
         tag:`[h2]`,
         replace:`<span style="display:block;" class="${theme.text.H2}">`

--- a/src/layouts/FlexibleLayouts.js
+++ b/src/layouts/FlexibleLayouts.js
@@ -45,6 +45,12 @@ export const pageQuery = graphql`
         ...TwoColBreakoutImageTextPage
         ...TwoColBreakoutImageHeadingPage
         ...TwoColTextQuotePage
+        ...TwoColTextQuoteCardPage
+        ...StepsWithCardPage
+        ...OverlapImageCardPage
+        ...StepsWithImagesPage
+        ...BulletsWithImagePage
+        ...ExpandableIconBoxesPage
         ...FlexibleProjectBlocksPage
         ...ProjectBlocksPage
         ...TextBlockPage
@@ -99,6 +105,12 @@ export const serviceQuery = graphql`
         ...TwoColBreakoutImageTextService
         ...TwoColBreakoutImageHeadingService 
         ...TwoColTextQuoteService
+        ...TwoColTextQuoteCardService
+        ...StepsWithCardService
+        ...OverlapImageCardService
+        ...StepsWithImagesService
+        ...BulletsWithImageService
+        ...ExpandableIconBoxesService
         ...FlexibleProjectBlocksService
         ...ProjectBlocksService
         ...TextBlockService
@@ -150,6 +162,12 @@ export const projectQuery = graphql`
         ...TwoColBreakoutImageTextProject
         ...TwoColBreakoutImageHeadingProject
         ...TwoColTextQuoteProject
+        ...TwoColTextQuoteCardProject
+        ...StepsWithCardProject
+        ...OverlapImageCardProject
+        ...StepsWithImagesProject
+        ...BulletsWithImageProject
+        ...ExpandableIconBoxesProject
         ...FlexibleProjectBlocksProject
         ...ProjectBlocksProject
         ...VideoPlayerProject

--- a/src/layouts/layoutIndex.js
+++ b/src/layouts/layoutIndex.js
@@ -23,6 +23,12 @@ import TwoColBreakoutImageHeading from "./layouts/TwoColBreakoutImageHeading"
 import TwoColImageText from "./layouts/TwoColImageText"
 import TwoColList from "./layouts/TwoColList"
 import TwoColTextQuote from "./layouts/TwoColTextQuote"
+import TwoColTextQuoteCard from "./layouts/TwoColTextQuoteCard"
+import StepsWithCard from "./layouts/StepsWithCard"
+import OverlapImageCard from "./layouts/OverlapImageCard"
+import StepsWithImages from "./layouts/StepsWithImages"
+import BulletsWithImage from "./layouts/BulletsWithImage"
+import ExpandableIconBoxes from "./layouts/ExpandableIconBoxes"
 import VennDiagram from "./layouts/VennDiagram"
 import VerticalSlider from "./layouts/VerticalSlider"
 import QuarterImageText from "./layouts/QuarterImageText"
@@ -84,6 +90,12 @@ Layouts['TwoColBreakoutImageHeading']       = TwoColBreakoutImageHeading;
 Layouts['TwoColImageText']                  = TwoColImageText;
 Layouts['TwoColList']                       = TwoColList;
 Layouts['TwoColTextQuote']                  = TwoColTextQuote;
+Layouts['TwoColTextQuoteCard']              = TwoColTextQuoteCard;
+Layouts['StepsWithCard']                    = StepsWithCard;
+Layouts['OverlapImageCard']                 = OverlapImageCard;
+Layouts['StepsWithImages']                  = StepsWithImages;
+Layouts['BulletsWithImage']                 = BulletsWithImage;
+Layouts['ExpandableIconBoxes']              = ExpandableIconBoxes;
 Layouts['VennDiagram']                      = VennDiagram;
 Layouts['QuarterImageText']                 = QuarterImageText;
 Layouts['CtaForm']                          = CtaForm;

--- a/src/layouts/layouts/BulletsWithImage.js
+++ b/src/layouts/layouts/BulletsWithImage.js
@@ -1,0 +1,192 @@
+import React from "react"
+import { graphql } from "gatsby"
+import { GatsbyImage } from "gatsby-plugin-image"
+import { Section, Container } from "../../components/global/Wrappers"
+import Parser from "../../components/global/Parser"
+
+const BulletsWithImage = (props) => {
+    const content    = props.layoutData.layoutContent
+    const settings   = props.layoutData.layoutSettings
+
+    const heading    = content.heading    ?? false
+    const introBody  = content.introBody  ?? false
+    const subHeading = content.subHeading ?? false
+    const bullets    = content.bullets    ?? []
+    const image      = content.image      ?? false
+    const outroBody  = content.outroBody  ?? false
+
+    const textColor  = settings.backgroundColor === 'black' ? 'text-white' : 'text-black'
+
+    let renderImage = null
+    if (image) {
+        renderImage = (image.localFile?.ext === '.svg')
+            ? <img src={image.sourceUrl} alt={image.altText || ''} className="w-full h-auto object-contain" />
+            : image.localFile?.childImageSharp?.gatsbyImageData
+                ? <GatsbyImage
+                    image={image.localFile.childImageSharp.gatsbyImageData}
+                    alt={image.altText || ''}
+                    className="w-full h-auto rounded-[20px]"
+                    objectFit="contain" />
+                : null
+    }
+
+    return (
+        <Section settings={settings}>
+            <Container container={settings.containerWidth}>
+                <div className="flex flex-col gap-10 lg:gap-[34px]">
+
+                    {(heading || introBody) &&
+                        <div className="flex flex-col gap-6 lg:gap-[34px] max-w-[1114px]">
+                            {heading &&
+                                <h2 className={`font-stratos font-semibold uppercase text-[40px] md:text-[50px] leading-[0.995] ${textColor}`}>
+                                    {heading}
+                                </h2>
+                            }
+                            {introBody &&
+                                <div
+                                    dangerouslySetInnerHTML={{ __html: Parser(introBody) }}
+                                    className={`font-basic-sans font-light text-[21px] leading-[28px] ${textColor} [&_p]:mb-4 [&_a]:underline [&_strong]:font-bold`}
+                                />
+                            }
+                        </div>
+                    }
+
+                    <div className="grid grid-cols-1 lg:grid-cols-2 gap-10 lg:gap-12 items-start">
+                        <div className="flex flex-col gap-4">
+                            {subHeading &&
+                                <p className={`font-basic-sans font-semibold text-[26px] leading-[36px] ${textColor}`}>
+                                    {subHeading}
+                                </p>
+                            }
+                            {bullets.length > 0 &&
+                                <ul className={`flex flex-col gap-3.5 font-basic-sans font-light text-[21px] leading-[28px] ${textColor}`}>
+                                    {bullets.map((b, idx) => (
+                                        <li key={`BulletsWithImageItem__${idx}`} className="flex items-start gap-4">
+                                            <span className="text-[24px] leading-[24px] shrink-0">•</span>
+                                            <span>{b.item}</span>
+                                        </li>
+                                    ))}
+                                </ul>
+                            }
+                        </div>
+                        {renderImage &&
+                            <div className="w-full flex items-center justify-center max-w-[750px] xl:max-w-full mx-auto">
+                                {renderImage}
+                            </div>
+                        }
+                    </div>
+
+                    {outroBody &&
+                        <div
+                            dangerouslySetInnerHTML={{ __html: Parser(outroBody) }}
+                            className={`font-basic-sans font-light text-[21px] leading-[28px] max-w-[1119px] ${textColor} [&_p]:mb-4 [&_a]:underline [&_strong]:font-bold`}
+                        />
+                    }
+
+                </div>
+            </Container>
+        </Section>
+    )
+}
+
+export default BulletsWithImage
+
+
+export const query = graphql`
+  fragment BulletsWithImagePage on WpPage_Flexiblelayouts_Layouts {
+    ... on WpPage_Flexiblelayouts_Layouts_BulletsWithImage {
+        fieldGroupName
+        layoutBulletsWithImage {
+          layoutContent {
+            heading
+            introBody
+            subHeading
+            bullets { item }
+            outroBody
+            image {
+              altText
+              sourceUrl
+              localFile {
+                ext
+                childImageSharp { gatsbyImageData }
+              }
+            }
+          }
+          layoutSettings {
+            padding { bottom top }
+            anchorId
+            backgroundColor
+            classes
+            id
+            containerWidth
+          }
+        }
+      }
+  }
+`
+
+export const serviceQuery = graphql`
+  fragment BulletsWithImageService on WpService_Flexiblelayouts_Layouts {
+    ... on WpService_Flexiblelayouts_Layouts_BulletsWithImage {
+        fieldGroupName
+        layoutBulletsWithImage {
+          layoutContent {
+            heading
+            introBody
+            subHeading
+            bullets { item }
+            outroBody
+            image {
+              altText
+              sourceUrl
+              localFile {
+                ext
+                childImageSharp { gatsbyImageData }
+              }
+            }
+          }
+          layoutSettings {
+            padding { bottom top }
+            anchorId
+            backgroundColor
+            classes
+            id
+            containerWidth
+          }
+        }
+      }
+  }
+`
+
+export const projectQuery = graphql`
+  fragment BulletsWithImageProject on WpProject_Flexiblelayouts_Layouts {
+    ... on WpProject_Flexiblelayouts_Layouts_BulletsWithImage {
+        fieldGroupName
+        layoutBulletsWithImage {
+          layoutContent {
+            heading
+            introBody
+            subHeading
+            bullets { item }
+            outroBody
+            image {
+              altText
+              sourceUrl
+              localFile {
+                ext
+                childImageSharp { gatsbyImageData }
+              }
+            }
+          }
+          layoutSettings {
+            padding { bottom top }
+            anchorId
+            backgroundColor
+            classes
+            id
+            containerWidth
+          }
+        }
+      }
+  }
+`

--- a/src/layouts/layouts/ExpandableIconBoxes.js
+++ b/src/layouts/layouts/ExpandableIconBoxes.js
@@ -1,0 +1,228 @@
+import React, { useState } from "react"
+import { graphql } from "gatsby"
+import { GatsbyImage } from "gatsby-plugin-image"
+import { Section, Container } from "../../components/global/Wrappers"
+import { theme } from "../../static/theme"
+import Parser from "../../components/global/Parser"
+
+const ExpandableIconBox = ({ box, idx, textColor }) => {
+    const [expanded, setExpanded] = useState(false)
+
+    const heading      = box.heading      ?? false
+    const body         = box.body         ?? false
+    const expandedBody = box.expandedBody ?? false
+    const icon         = box.image        ?? false
+
+    let renderIcon = null
+    if (icon) {
+        renderIcon = (icon.localFile?.ext === '.svg')
+            ? <img src={icon.sourceUrl} alt={icon.altText || ''} className="w-auto h-[55px] object-contain" />
+            : icon.localFile?.childImageSharp?.gatsbyImageData
+                ? <GatsbyImage
+                    image={icon.localFile.childImageSharp.gatsbyImageData}
+                    alt={icon.altText || ''}
+                    className="w-auto h-[55px]"
+                    objectFit="contain" />
+                : null
+    }
+
+    return (
+        <div key={`ExpandableIconBox__${idx}`} className="flex gap-5 items-start">
+            {renderIcon &&
+                <div className="w-[60px] shrink-0">
+                    {renderIcon}
+                </div>
+            }
+            <div className="flex flex-col gap-6 flex-1 min-w-0">
+                {heading &&
+                    <h3 className={`font-basic-sans font-semibold text-[26px] leading-[32px] ${textColor}`}>
+                        {heading}
+                    </h3>
+                }
+                {body &&
+                    <p
+                        dangerouslySetInnerHTML={{ __html: Parser(body) }}
+                        className={`font-basic-sans font-normal text-[18px] leading-[26px] ${textColor}`}
+                    />
+                }
+                {expandedBody && expanded &&
+                    <div
+                        dangerouslySetInnerHTML={{ __html: Parser(expandedBody) }}
+                        className={`font-basic-sans font-normal text-[18px] leading-[26px] ${textColor} [&_p]:mb-4 [&_p:last-child]:mb-0 [&_a]:underline [&_strong]:font-bold`}
+                    />
+                }
+                {expandedBody &&
+                    <button
+                        type="button"
+                        onClick={() => setExpanded(!expanded)}
+                        aria-expanded={expanded}
+                        className={`${theme.text_links.BASE_STYLING} ${theme.text_links.STD}  text-[#A9CF38] uppercase font-stratos text-[21px] leading-[28px] inline-flex items-center gap-2 self-start cursor-pointer`}
+                    >
+                        {expanded ? 'Read Less – ' : 'Read More + '}
+                    </button>
+                }
+            </div>
+        </div>
+    )
+}
+
+const ExpandableIconBoxes = (props) => {
+    const content   = props.layoutData.layoutContent
+    const settings  = props.layoutData.layoutSettings
+
+    const heading   = content.heading   ?? false
+    const introBody = content.introBody ?? false
+    const columns   = Number(content.columns) || 2
+    const boxes     = content.boxes     ?? []
+
+    const textColor = settings.backgroundColor === 'black' ? 'text-white' : 'text-black'
+
+    const gridCols = columns === 3
+        ? 'md:grid-cols-2 xl:grid-cols-3'
+        : 'md:grid-cols-2'
+
+    return (
+        <Section settings={settings}>
+            <Container container={settings.containerWidth}>
+                <div className="flex flex-col gap-10 lg:gap-[43px] items-center">
+
+                    {(heading || introBody) &&
+                        <div className="flex flex-col gap-6 text-center max-w-[1122px]">
+                            {heading &&
+                                <h2 className={`font-stratos font-semibold uppercase text-[40px] md:text-[50px] leading-[0.995] ${textColor}`}>
+                                    {heading}
+                                </h2>
+                            }
+                            {introBody &&
+                                <div
+                                    dangerouslySetInnerHTML={{ __html: Parser(introBody) }}
+                                    className={`font-basic-sans font-light text-[21px] leading-[28px] ${textColor} [&_p]:mb-4 [&_p:last-child]:mb-0 [&_a]:underline [&_strong]:font-bold`}
+                                />
+                            }
+                        </div>
+                    }
+
+                    {boxes.length > 0 &&
+                        <div className={`grid grid-cols-1 ${gridCols} gap-x-12 gap-y-16 lg:gap-x-[46px] lg:gap-y-[97px] w-full items-start`}>
+                            {boxes.map((box, idx) => (
+                                <ExpandableIconBox key={idx} box={box} idx={idx} textColor={textColor} />
+                            ))}
+                        </div>
+                    }
+
+                </div>
+            </Container>
+        </Section>
+    )
+}
+
+export default ExpandableIconBoxes
+
+
+export const query = graphql`
+  fragment ExpandableIconBoxesPage on WpPage_Flexiblelayouts_Layouts {
+    ... on WpPage_Flexiblelayouts_Layouts_ExpandableIconBoxes {
+        fieldGroupName
+        layoutExpandableIconBoxes {
+          layoutContent {
+            heading
+            introBody
+            columns
+            boxes {
+              heading
+              body
+              expandedBody
+              image {
+                altText
+                sourceUrl
+                localFile {
+                  ext
+                  childImageSharp { gatsbyImageData }
+                }
+              }
+            }
+          }
+          layoutSettings {
+            padding { bottom top }
+            anchorId
+            backgroundColor
+            classes
+            id
+            containerWidth
+          }
+        }
+      }
+  }
+`
+
+export const serviceQuery = graphql`
+  fragment ExpandableIconBoxesService on WpService_Flexiblelayouts_Layouts {
+    ... on WpService_Flexiblelayouts_Layouts_ExpandableIconBoxes {
+        fieldGroupName
+        layoutExpandableIconBoxes {
+          layoutContent {
+            heading
+            introBody
+            columns
+            boxes {
+              heading
+              body
+              expandedBody
+              image {
+                altText
+                sourceUrl
+                localFile {
+                  ext
+                  childImageSharp { gatsbyImageData }
+                }
+              }
+            }
+          }
+          layoutSettings {
+            padding { bottom top }
+            anchorId
+            backgroundColor
+            classes
+            id
+            containerWidth
+          }
+        }
+      }
+  }
+`
+
+export const projectQuery = graphql`
+  fragment ExpandableIconBoxesProject on WpProject_Flexiblelayouts_Layouts {
+    ... on WpProject_Flexiblelayouts_Layouts_ExpandableIconBoxes {
+        fieldGroupName
+        layoutExpandableIconBoxes {
+          layoutContent {
+            heading
+            introBody
+            columns
+            boxes {
+              heading
+              body
+              expandedBody
+              image {
+                altText
+                sourceUrl
+                localFile {
+                  ext
+                  childImageSharp { gatsbyImageData }
+                }
+              }
+            }
+          }
+          layoutSettings {
+            padding { bottom top }
+            anchorId
+            backgroundColor
+            classes
+            id
+            containerWidth
+          }
+        }
+      }
+  }
+`

--- a/src/layouts/layouts/FullWidthImageVideoText.js
+++ b/src/layouts/layouts/FullWidthImageVideoText.js
@@ -90,7 +90,7 @@ const FullWidthImageVideoText = (props) => {
             }
 
             {content.mobile &&
-              <video ref={mobileVideo} className="md:hidden block mx-auto" controls={false} muted loop={true}>
+              <video ref={mobileVideo} className="md:hidden block mx-auto" controls={false} muted loop={true} playsInline>
                   <source src={content.mobile.mediaItemUrl} type={content.mobile.mimeType} />
               </video>
             }

--- a/src/layouts/layouts/IconTextBoxes.js
+++ b/src/layouts/layouts/IconTextBoxes.js
@@ -85,6 +85,7 @@ const IconTextBoxes = (props) => {
     //added code to dynamically set mt on wrapper div depending on stack or flex (icon placement affects margin needed)
     const wrapperClasses = (content.settings.type === 'stack') ? `${(content.heading || content.subheading) ? 'mt-0' : 'mt-0'} grid gap-x-8 gap-y-6 md:grid-cols-2 md:gap-y-12 ${cols} gap-8 max-w-[1100px] mx-auto` : `${(!content.heading && !content.subheading) ? 'mt-0' : 'mt-16'} flex w-full flex-wrap justify-between ${flexDirection} threeColIconsText ${hasSingleLastItem ? '[&>*:last-child]:mx-auto' : ''}`;
 
+
   return (
       <Section settings={settings}>
           <Container container={settings.containerWidth}>

--- a/src/layouts/layouts/OverlapImageCard.js
+++ b/src/layouts/layouts/OverlapImageCard.js
@@ -1,0 +1,206 @@
+import React from "react"
+import { graphql } from "gatsby"
+import { GatsbyImage } from "gatsby-plugin-image"
+import { Section, Container } from "../../components/global/Wrappers"
+import Parser from "../../components/global/Parser"
+import Buttons from "../../components/global/Buttons"
+
+const OverlapImageCard = (props) => {
+    const content                  = props.layoutData.layoutContent
+    const settings                 = props.layoutData.layoutSettings
+
+    const body                     = content.body            ?? false
+    const componentButton          = content.componentButton ?? false
+    const image                    = content.image           ?? false
+    const imagePosition            = content.imagePosition   ?? 'left'
+    const halfBackground           = content.halfBackground  ?? false
+    const halfBackgroundColor      = content.halfBackgroundColor    ?? 'rm-pale-grey'
+    const halfBackgroundPosition   = content.halfBackgroundPosition ?? 'top'
+
+    let renderImage = null
+    if (image) {
+        renderImage = (image.localFile?.ext === '.svg')
+            ? <img src={image.sourceUrl} alt={image.altText || ''} className="w-full h-full object-cover rounded-[12px]" />
+            : image.localFile?.childImageSharp?.gatsbyImageData
+                ? <GatsbyImage
+                    image={image.localFile.childImageSharp.gatsbyImageData}
+                    alt={image.altText || ''}
+                    className="w-full h-full rounded-[12px]"
+                    objectFit="cover" />
+                : null
+    }
+
+    return (
+        <Section settings={settings}>
+            {halfBackground &&
+                <div className={`absolute left-0 w-full h-1/2 bg-${halfBackgroundColor} ${halfBackgroundPosition === 'bottom' ? 'bottom-0' : 'top-0'}`} aria-hidden="true"></div>
+            }
+            <Container container="default">
+                <div className="relative bg-rm-white rounded-[20px] shadow-[0_0_5px_0_rgba(0,0,0,0.1)] flex flex-col xl:flex-row gap-8 xl:gap-[26px] items-center p-8 md:p-12 xl:p-[80px] mx-2">
+
+                    {renderImage &&
+                        <div className={`w-full xl:w-1/2 xl:max-w-[465px] aspect-[465/343] overflow-hidden rounded-[12px] ${imagePosition === 'right' ? 'xl:order-2' : ''}`}>
+                            {renderImage}
+                        </div>
+                    }
+
+                    <div className={`flex flex-col gap-8 w-full xl:w-1/2 xl:max-w-[466px] ${imagePosition === 'right' ? 'xl:order-1' : ''}`}>
+                        {body &&
+                            <div
+                                dangerouslySetInnerHTML={{ __html: Parser(body) }}
+                                className="font-basic-sans font-light text-[21px] leading-[28px] text-black [&_p]:mb-4 [&_strong]:font-bold [&_a]:underline"
+                            />
+                        }
+                        {componentButton?.link?.url &&
+                            <div>
+                                <Buttons content={componentButton} sectionBackground="white" />
+                            </div>
+                        }
+                    </div>
+
+                </div>
+            </Container>
+        </Section>
+    )
+}
+
+export default OverlapImageCard
+
+
+export const query = graphql`
+  fragment OverlapImageCardPage on WpPage_Flexiblelayouts_Layouts {
+    ... on WpPage_Flexiblelayouts_Layouts_OverlapImageCard {
+        fieldGroupName
+        layoutOverlapImageCard {
+          layoutContent {
+            body
+            imagePosition
+            halfBackground
+            halfBackgroundColor
+            halfBackgroundPosition
+            componentButton {
+              fieldGroupName
+              colors {
+                fieldGroupName
+                resting
+              }
+              link {
+                url
+                title
+                target
+              }
+              style
+            }
+            image {
+              altText
+              sourceUrl
+              localFile {
+                ext
+                childImageSharp { gatsbyImageData }
+              }
+            }
+          }
+          layoutSettings {
+            padding { bottom top }
+            anchorId
+            backgroundColor
+            classes
+            id
+            containerWidth
+          }
+        }
+      }
+  }
+`
+
+export const serviceQuery = graphql`
+  fragment OverlapImageCardService on WpService_Flexiblelayouts_Layouts {
+    ... on WpService_Flexiblelayouts_Layouts_OverlapImageCard {
+        fieldGroupName
+        layoutOverlapImageCard {
+          layoutContent {
+            body
+            imagePosition
+            halfBackground
+            halfBackgroundColor
+            halfBackgroundPosition
+            componentButton {
+              fieldGroupName
+              colors {
+                fieldGroupName
+                resting
+              }
+              link {
+                url
+                title
+                target
+              }
+              style
+            }
+            image {
+              altText
+              sourceUrl
+              localFile {
+                ext
+                childImageSharp { gatsbyImageData }
+              }
+            }
+          }
+          layoutSettings {
+            padding { bottom top }
+            anchorId
+            backgroundColor
+            classes
+            id
+            containerWidth
+          }
+        }
+      }
+  }
+`
+
+export const projectQuery = graphql`
+  fragment OverlapImageCardProject on WpProject_Flexiblelayouts_Layouts {
+    ... on WpProject_Flexiblelayouts_Layouts_OverlapImageCard {
+        fieldGroupName
+        layoutOverlapImageCard {
+          layoutContent {
+            body
+            imagePosition
+            halfBackground
+            halfBackgroundColor
+            halfBackgroundPosition
+            componentButton {
+              fieldGroupName
+              colors {
+                fieldGroupName
+                resting
+              }
+              link {
+                url
+                title
+                target
+              }
+              style
+            }
+            image {
+              altText
+              sourceUrl
+              localFile {
+                ext
+                childImageSharp { gatsbyImageData }
+              }
+            }
+          }
+          layoutSettings {
+            padding { bottom top }
+            anchorId
+            backgroundColor
+            classes
+            id
+            containerWidth
+          }
+        }
+      }
+  }
+`

--- a/src/layouts/layouts/Results.js
+++ b/src/layouts/layouts/Results.js
@@ -15,7 +15,7 @@ const Results = (props) => {
 
     return(
         <Section settings={settings}>
-            <Container>
+            <Container container={settings.containerWidth}>
                 {content.heading &&
                   <h2 className={'text-center mb-4'}>
                       <span 
@@ -68,6 +68,7 @@ export const query = graphql`
             backgroundColor
             classes
             id
+            containerWidth
           }
         }
       }
@@ -97,6 +98,7 @@ export const serviceQuery = graphql`
             backgroundColor
             classes
             id
+            containerWidth
           }
         }
       }
@@ -127,6 +129,7 @@ export const projectQuery = graphql`
             backgroundColor
             classes
             id
+            containerWidth
           }
         }
       }
@@ -157,6 +160,7 @@ export const landerQuery = graphql`
             backgroundColor
             classes
             id
+            containerWidth
           }
         }
       }

--- a/src/layouts/layouts/StepsWithCard.js
+++ b/src/layouts/layouts/StepsWithCard.js
@@ -53,7 +53,7 @@ const StepsWithCard = (props) => {
                                 {card.body &&
                                     <div
                                         dangerouslySetInnerHTML={{ __html: Parser(card.body) }}
-                                        className="font-basic-sans font-light text-[21px] leading-[28px] [&_p]:mb-4 [&_a]:underline [&_strong]:font-bold"
+                                        className="font-basic-sans font-light text-[21px] leading-[28px] [&_p]:mb-4 [&_a]:underline [&_strong]:font-bold max-w-[750px]"
                                     />
                                 }
                             </div>

--- a/src/layouts/layouts/StepsWithCard.js
+++ b/src/layouts/layouts/StepsWithCard.js
@@ -1,0 +1,255 @@
+import React from "react"
+import { GatsbyImage } from "gatsby-plugin-image"
+import { Section, Container } from "../../components/global/Wrappers"
+import { theme } from "../../static/theme"
+import { graphql } from "gatsby"
+import Parser from "../../components/global/Parser"
+
+const StepsWithCard = (props) => {
+
+    const content  = props.layoutData.layoutContent
+    const settings = props.layoutData.layoutSettings
+    const steps    = content?.steps || []
+    const card     = content?.card
+
+    const textColor = settings.backgroundColor === 'black' ? 'text-rm-white' : 'text-rm-black'
+
+    return (
+        <Section settings={settings}>
+            <Container container={settings.containerWidth}>
+                <div className="flex flex-col gap-12 lg:gap-[50px] items-center">
+
+                    {steps.length > 0 &&
+                        <div className="grid grid-cols-1 md:grid-cols-2 gap-8 lg:gap-[31px] w-full">
+                            {steps.map((step, idx) => (
+                                <div key={`StepsWithCardStep__${idx}`} className="flex flex-col gap-[18px] items-start">
+                                    <span className={`${theme.text.CIRCLE_NUM} w-[55px] h-[55px] text-rm-green border-rm-green`}>
+                                        {idx + 1}
+                                    </span>
+                                    {step.heading &&
+                                        <h3 className={`font-basic-sans font-bold text-[21px] leading-[28px] ${textColor}`}>
+                                            {step.heading}
+                                        </h3>
+                                    }
+                                    {step.body &&
+                                        <div
+                                            dangerouslySetInnerHTML={{ __html: Parser(step.body) }}
+                                            className={`font-basic-sans font-light text-[21px] leading-[28px] ${textColor} [&_a]:underline`}
+                                        />
+                                    }
+                                </div>
+                            ))}
+                        </div>
+                    }
+
+                    {(card?.heading || card?.body || card?.image || card?.imageMobile) &&
+                        <div className="bg-[#1F9DA5] rounded-[20px] overflow-hidden w-full grid grid-cols-1 lg:grid-cols-[1fr_302px] items-stretch max-w-[750px] lg:max-w-full mx-auto">
+                            <div className="flex flex-col gap-1.5 p-8 lg:pl-[58px] lg:pr-12 lg:py-12 text-rm-white">
+                                {card.heading &&
+                                    <h3 className="font-basic-sans font-semibold text-[28px] md:text-[34px] leading-tight">
+                                        {card.heading}
+                                    </h3>
+                                }
+                                {card.body &&
+                                    <div
+                                        dangerouslySetInnerHTML={{ __html: Parser(card.body) }}
+                                        className="font-basic-sans font-light text-[21px] leading-[28px] [&_p]:mb-4 [&_a]:underline [&_strong]:font-bold"
+                                    />
+                                }
+                            </div>
+                            {card.imageMobile && (
+                                <div className="lg:hidden">
+                                    {card.imageMobile.localFile?.childImageSharp?.gatsbyImageData
+                                        ? <GatsbyImage
+                                            image={card.imageMobile.localFile.childImageSharp.gatsbyImageData}
+                                            alt={card.imageMobile.altText || ''}
+                                            className="w-full h-full min-h-[260px]"
+                                            objectFit="cover" />
+                                        : card.imageMobile.sourceUrl &&
+                                            <img
+                                                src={card.imageMobile.sourceUrl}
+                                                alt={card.imageMobile.altText || ''}
+                                                className="w-full h-full min-h-[260px] object-cover" />
+                                    }
+                                </div>
+                            )}
+                            {card.image && (
+                                <div className={`${card.imageMobile ? 'hidden lg:block' : ''}`}>
+                                    {card.image.localFile?.childImageSharp?.gatsbyImageData
+                                        ? <GatsbyImage
+                                            image={card.image.localFile.childImageSharp.gatsbyImageData}
+                                            alt={card.image.altText || ''}
+                                            className="w-full h-full min-h-[260px] lg:min-h-full"
+                                            objectFit="cover" />
+                                        : card.image.sourceUrl &&
+                                            <img
+                                                src={card.image.sourceUrl}
+                                                alt={card.image.altText || ''}
+                                                className="w-full h-full min-h-[260px] lg:min-h-full object-cover" />
+                                    }
+                                </div>
+                            )}
+                        </div>
+                    }
+
+                </div>
+            </Container>
+        </Section>
+    )
+}
+
+export default StepsWithCard
+
+
+export const query = graphql`
+  fragment StepsWithCardPage on WpPage_Flexiblelayouts_Layouts {
+    ... on WpPage_Flexiblelayouts_Layouts_StepsWithCard {
+        fieldGroupName
+        layoutStepsWithCard {
+          layoutContent {
+            steps {
+              heading
+              body
+            }
+            card {
+              heading
+              body
+              image {
+                localFile {
+                  ext
+                  childImageSharp {
+                    gatsbyImageData
+                  }
+                }
+                altText
+                sourceUrl
+              }
+              imageMobile {
+                localFile {
+                  ext
+                  childImageSharp {
+                    gatsbyImageData
+                  }
+                }
+                altText
+                sourceUrl
+              }
+            }
+          }
+          layoutSettings {
+            padding {
+              bottom
+              top
+            }
+            anchorId
+            backgroundColor
+            classes
+            id
+            containerWidth
+          }
+        }
+      }
+  }
+`
+
+export const serviceQuery = graphql`
+  fragment StepsWithCardService on WpService_Flexiblelayouts_Layouts {
+    ... on WpService_Flexiblelayouts_Layouts_StepsWithCard {
+        fieldGroupName
+        layoutStepsWithCard {
+          layoutContent {
+            steps {
+              heading
+              body
+            }
+            card {
+              heading
+              body
+              image {
+                localFile {
+                  ext
+                  childImageSharp {
+                    gatsbyImageData
+                  }
+                }
+                altText
+                sourceUrl
+              }
+              imageMobile {
+                localFile {
+                  ext
+                  childImageSharp {
+                    gatsbyImageData
+                  }
+                }
+                altText
+                sourceUrl
+              }
+            }
+          }
+          layoutSettings {
+            padding {
+              bottom
+              top
+            }
+            anchorId
+            backgroundColor
+            classes
+            id
+            containerWidth
+          }
+        }
+      }
+  }
+`
+
+export const projectQuery = graphql`
+  fragment StepsWithCardProject on WpProject_Flexiblelayouts_Layouts {
+    ... on WpProject_Flexiblelayouts_Layouts_StepsWithCard {
+        fieldGroupName
+        layoutStepsWithCard {
+          layoutContent {
+            steps {
+              heading
+              body
+            }
+            card {
+              heading
+              body
+              image {
+                localFile {
+                  ext
+                  childImageSharp {
+                    gatsbyImageData
+                  }
+                }
+                altText
+                sourceUrl
+              }
+              imageMobile {
+                localFile {
+                  ext
+                  childImageSharp {
+                    gatsbyImageData
+                  }
+                }
+                altText
+                sourceUrl
+              }
+            }
+          }
+          layoutSettings {
+            padding {
+              bottom
+              top
+            }
+            anchorId
+            backgroundColor
+            classes
+            id
+            containerWidth
+          }
+        }
+      }
+  }
+`

--- a/src/layouts/layouts/StepsWithImages.js
+++ b/src/layouts/layouts/StepsWithImages.js
@@ -1,0 +1,394 @@
+import React from "react"
+import { graphql } from "gatsby"
+import { GatsbyImage } from "gatsby-plugin-image"
+import { Section, Container } from "../../components/global/Wrappers"
+import { theme } from "../../static/theme"
+import Parser from "../../components/global/Parser"
+import Buttons from "../../components/global/Buttons"
+
+const OverlapCard = ({ card, container, padding }) => {
+    const body            = card?.body            ?? false
+    const componentButton = card?.componentButton ?? false
+    const image           = card?.image           ?? false
+    const imagePosition   = card?.imagePosition   ?? 'left'
+
+
+    const halfBackground         = card?.halfBackground         ?? false
+    const halfBackgroundColor    = card?.halfBackgroundColor    ?? 'rm-pale-grey'
+    const halfBackgroundPosition = card?.halfBackgroundPosition ?? 'top'
+
+    if (!body && !image && !componentButton?.link?.url) return null
+
+    let renderImage = null
+    if (image) {
+        renderImage = (image.localFile?.ext === '.svg')
+            ? <img src={image.sourceUrl} alt={image.altText || ''} className="w-full h-full object-cover " />
+            : image.localFile?.childImageSharp?.gatsbyImageData
+                ? <GatsbyImage
+                    image={image.localFile.childImageSharp.gatsbyImageData}
+                    alt={image.altText || ''}
+                    className="w-full h-full "
+                    objectFit="cover" />
+                : null
+    }
+
+    return (<>
+     {halfBackground &&
+        <div
+            aria-hidden="true"
+            className={` ${theme.paddingTop[`${padding}`] } absolute left-0 w-full pointer-events-none bg-${halfBackgroundColor} ${halfBackgroundPosition === 'bottom' ? 'bottom-0' : 'top-0'}`}
+        />
+      }
+    <div className="relative">
+        {halfBackground &&
+          <div
+              aria-hidden="true"
+              className={`absolute left-0 w-full h-1/2 pointer-events-none bg-${halfBackgroundColor} ${halfBackgroundPosition === 'bottom' ? 'bottom-0' : 'top-0'}`}
+          />
+        }
+        <Container container={container}>
+          <div className="relative bg-rm-white rounded-[20px] shadow-[0_0_5px_0_rgba(0,0,0,0.1)] flex flex-col xl:flex-row gap-8 xl:gap-[26px] items-center p-8 md:p-12 xl:p-[80px] mb-12 lg:mb-[59px] max-w-[750px] xl:max-w-full mx-auto">
+              {renderImage &&
+                  <div className={`w-full xl:w-1/2 xl:max-w-[465px] aspect-[465/343] overflow-hidden  ${imagePosition === 'right' ? 'xl:order-2' : ''}`}>
+                      {renderImage}
+                  </div>
+              }
+              <div className={`flex flex-col gap-8 w-full xl:w-1/2 xl:max-w-[466px] ${imagePosition === 'right' ? 'xl:order-1' : ''}`}>
+                  {body &&
+                      <div
+                          dangerouslySetInnerHTML={{ __html: Parser(body) }}
+                          className="font-basic-sans font-light text-[21px] leading-[28px] text-black [&_p]:mb-4 [&_strong]:font-bold [&_a]:underline"
+                      />
+                  }
+                  {componentButton?.link?.url &&
+                      <div>
+                          <Buttons content={componentButton} sectionBackground="white" />
+                      </div>
+                  }
+              </div>
+          </div>
+        </Container>
+    </div>
+    </>)
+}
+
+const StepsWithImages = (props) => {
+    const content            = props.layoutData.layoutContent
+    const settings           = props.layoutData.layoutSettings
+
+    const heading            = content.heading            ?? false
+    const intro              = content.intro              ?? false
+    const stepRows           = content.stepRows           ?? []
+    const backgroundGradient = content.backgroundGradient ?? false
+    const card               = content.card               ?? false
+
+    let stepCounter = 0
+
+    return (
+        <Section settings={settings}>
+            {backgroundGradient && <>
+                <div
+                    aria-hidden="true"
+                    className="absolute inset-0 pointer-events-none bg-[#f3f1ee]"
+                />
+                <div
+                    aria-hidden="true"
+                    className="absolute inset-0 pointer-events-none -scale-y-100"
+                    style={{ backgroundImage: 'linear-gradient(120.76deg, rgba(0,171,182,0) 74.15%, rgba(0,171,182,0.6) 163.32%)' }}
+                />
+                <div
+                    aria-hidden="true"
+                    className="absolute inset-0 pointer-events-none -scale-y-100"
+                    style={{ backgroundImage: 'linear-gradient(321deg, rgba(0,171,182,0) 74.15%, rgba(0,171,182,0.6) 163.32%)' }}
+                />
+            </>}
+
+
+            {card && <OverlapCard card={card} container={settings.containerWidth} padding={settings.padding.top} />}
+
+            <Container container={settings.containerWidth}>
+                <div className="relative flex flex-col gap-12 lg:gap-[59px]">
+
+                    {(heading || intro) &&
+                        <div className="flex flex-col gap-6 lg:gap-[34px]">
+                            {heading &&
+                                <h2 className="font-stratos font-semibold uppercase text-[40px] md:text-[50px] leading-[0.995] text-black">
+                                    {heading}
+                                </h2>
+                            }
+                            {intro &&
+                                <p
+                                    dangerouslySetInnerHTML={{ __html: Parser(intro) }}
+                                    className="font-basic-sans font-light text-[21px] leading-[28px] text-black"
+                                />
+                            }
+                        </div>
+                    }
+
+                    {stepRows.length > 0 &&
+                        <div className="flex flex-col gap-12 lg:gap-[59px]">
+                            {stepRows.map((row, rowIdx) => {
+                                const imageOnLeft = rowIdx % 2 === 1
+                                const rowImage    = row.image
+                                const steps       = row.steps || []
+
+                                let renderImage = null
+                                if (rowImage) {
+                                    renderImage = (rowImage.localFile?.ext === '.svg')
+                                        ? <img src={rowImage.sourceUrl} alt={rowImage.altText || ''} className="w-full h-full object-contain rounded-[20px]" />
+                                        : rowImage.localFile?.childImageSharp?.gatsbyImageData
+                                            ? <GatsbyImage
+                                                image={rowImage.localFile.childImageSharp.gatsbyImageData}
+                                                alt={rowImage.altText || ''}
+                                                className="w-full h-full rounded-[20px]"
+                                                objectFit="contain" />
+                                            : null
+                                }
+
+                                return (
+                                    <div
+                                        key={`StepsWithImagesRow__${rowIdx}`}
+                                        className="flex flex-col lg:flex-row gap-8 lg:gap-[26px] items-start"
+                                    >
+                                        {renderImage &&
+                                            <div className={`w-full lg:min-w-[485px] sm:max-w-[485px] overflow-hidden rounded-[20px] lg:self-center ${imageOnLeft ? 'lg:order-1' : 'lg:order-2'}`}>
+                                                {renderImage}
+                                            </div>
+                                        }
+
+                                        <div className={`flex flex-col gap-8 lg:gap-[31px] ${imageOnLeft ? 'lg:order-2' : 'lg:order-1'}`}>
+                                            {steps.map((step, stepIdx) => {
+                                                stepCounter += 1
+                                                return (
+                                                    <div key={`StepsWithImagesStep__${rowIdx}__${stepIdx}`} className="flex flex-col gap-4">
+                                                        <div className="flex items-center gap-3 lg:gap-[13px]">
+                                                            <span className={`${theme.text.CIRCLE_NUM} w-[55px] h-[55px] shrink-0 text-rm-green border-rm-green`}>
+                                                                {stepCounter}
+                                                            </span>
+                                                            {step.heading &&
+                                                                <h3 className="font-basic-sans font-bold text-[21px] leading-[28px] text-black">
+                                                                    {step.heading}
+                                                                </h3>
+                                                            }
+                                                        </div>
+                                                        {step.body &&
+                                                            <div
+                                                                dangerouslySetInnerHTML={{ __html: Parser(step.body) }}
+                                                                className="font-basic-sans font-light text-[21px] leading-[28px] text-black [&_p]:mb-4 [&_a]:underline [&_strong]:font-bold"
+                                                            />
+                                                        }
+                                                        {step.componentButton?.link?.url &&
+                                                            <div className="mt-2">
+                                                                <Buttons content={step.componentButton} sectionBackground={settings.backgroundColor || 'white'} />
+                                                            </div>
+                                                        }
+                                                    </div>
+                                                )
+                                            })}
+                                        </div>
+                                    </div>
+                                )
+                            })}
+                        </div>
+                    }
+
+                </div>
+            </Container>
+        </Section>
+    )
+}
+
+export default StepsWithImages
+
+
+export const query = graphql`
+  fragment StepsWithImagesPage on WpPage_Flexiblelayouts_Layouts {
+    ... on WpPage_Flexiblelayouts_Layouts_StepsWithImages {
+        fieldGroupName
+        layoutStepsWithImages {
+          layoutContent {
+            heading
+            intro
+            backgroundGradient
+            card {
+              body
+              imagePosition
+              halfBackground
+              halfBackgroundColor
+              halfBackgroundPosition
+              image {
+                altText
+                sourceUrl
+                localFile {
+                  ext
+                  childImageSharp { gatsbyImageData }
+                }
+              }
+              componentButton {
+                fieldGroupName
+                colors { fieldGroupName resting }
+                link { url title target }
+                style
+              }
+            }
+            stepRows {
+              image {
+                altText
+                sourceUrl
+                localFile {
+                  ext
+                  childImageSharp { gatsbyImageData }
+                }
+              }
+              steps {
+                heading
+                body
+                componentButton {
+                  fieldGroupName
+                  colors { fieldGroupName resting }
+                  link { url title target }
+                  style
+                }
+              }
+            }
+          }
+          layoutSettings {
+            padding { bottom top }
+            anchorId
+            backgroundColor
+            classes
+            id
+            containerWidth
+          }
+        }
+      }
+  }
+`
+
+export const serviceQuery = graphql`
+  fragment StepsWithImagesService on WpService_Flexiblelayouts_Layouts {
+    ... on WpService_Flexiblelayouts_Layouts_StepsWithImages {
+        fieldGroupName
+        layoutStepsWithImages {
+          layoutContent {
+            heading
+            intro
+            backgroundGradient
+            card {
+              body
+              imagePosition
+              halfBackground
+              halfBackgroundColor
+              halfBackgroundPosition
+              image {
+                altText
+                sourceUrl
+                localFile {
+                  ext
+                  childImageSharp { gatsbyImageData }
+                }
+              }
+              componentButton {
+                fieldGroupName
+                colors { fieldGroupName resting }
+                link { url title target }
+                style
+              }
+            }
+            stepRows {
+              image {
+                altText
+                sourceUrl
+                localFile {
+                  ext
+                  childImageSharp { gatsbyImageData }
+                }
+              }
+              steps {
+                heading
+                body
+                componentButton {
+                  fieldGroupName
+                  colors { fieldGroupName resting }
+                  link { url title target }
+                  style
+                }
+              }
+            }
+          }
+          layoutSettings {
+            padding { bottom top }
+            anchorId
+            backgroundColor
+            classes
+            id
+            containerWidth
+          }
+        }
+      }
+  }
+`
+
+export const projectQuery = graphql`
+  fragment StepsWithImagesProject on WpProject_Flexiblelayouts_Layouts {
+    ... on WpProject_Flexiblelayouts_Layouts_StepsWithImages {
+        fieldGroupName
+        layoutStepsWithImages {
+          layoutContent {
+            heading
+            intro
+            backgroundGradient
+            card {
+              body
+              imagePosition
+              halfBackground
+              halfBackgroundColor
+              halfBackgroundPosition
+              image {
+                altText
+                sourceUrl
+                localFile {
+                  ext
+                  childImageSharp { gatsbyImageData }
+                }
+              }
+              componentButton {
+                fieldGroupName
+                colors { fieldGroupName resting }
+                link { url title target }
+                style
+              }
+            }
+            stepRows {
+              image {
+                altText
+                sourceUrl
+                localFile {
+                  ext
+                  childImageSharp { gatsbyImageData }
+                }
+              }
+              steps {
+                heading
+                body
+                componentButton {
+                  fieldGroupName
+                  colors { fieldGroupName resting }
+                  link { url title target }
+                  style
+                }
+              }
+            }
+          }
+          layoutSettings {
+            padding { bottom top }
+            anchorId
+            backgroundColor
+            classes
+            id
+            containerWidth
+          }
+        }
+      }
+  }
+`

--- a/src/layouts/layouts/TwoColBreakoutImageHeading.js
+++ b/src/layouts/layouts/TwoColBreakoutImageHeading.js
@@ -38,7 +38,7 @@ const TwoColBreakoutImageHeading = (props) => {
                   </div>
                   <div className={`lg:max-w-1/2`}></div>
               </div>
-              </div>
+            </div>
           </Container>
         </Section>
     )

--- a/src/layouts/layouts/TwoColTextQuote.js
+++ b/src/layouts/layouts/TwoColTextQuote.js
@@ -8,7 +8,6 @@ import { motion } from "framer-motion"
 const TwoColTextQuote = (props) => {
 
     const content     = props.layoutData.layoutContent;
-    //console.log(content);
     const settings    = props.layoutData.layoutSettings;
     const textColor   = settings.backgroundColor === 'black' ? 'text-rm-white' : 'text-rm-black'; 
     const quotations  = content.quoteContent.quotations;

--- a/src/layouts/layouts/TwoColTextQuoteCard.js
+++ b/src/layouts/layouts/TwoColTextQuoteCard.js
@@ -1,0 +1,184 @@
+import React from "react"
+import { Section, Container } from "../../components/global/Wrappers"
+import { graphql } from "gatsby"
+import Parser from "../../components/global/Parser"
+import { motion } from "framer-motion"
+
+const TwoColTextQuoteCard = (props) => {
+
+    const content   = props.layoutData.layoutContent
+    const settings  = props.layoutData.layoutSettings
+    const text      = content.textContent
+    const quoteCard = content.quoteContent
+    const quoteOnLeft = content.quotePosition === 'left'
+
+    return (
+        <Section settings={settings}>
+            <Container container={settings.containerWidth}>
+                {content &&
+                    <div className="flex flex-col xl:grid xl:grid-cols-[1fr_408px] gap-12 xl:gap-[59px] items-center">
+                        <motion.div
+                            className={`flex flex-col gap-6 xl:gap-[34px] ${quoteOnLeft ? 'xl:order-2' : ''}`}
+                            initial={{ x: 0 }}
+                            animate={{ x: 0 }}
+                            transition={{ ease: "easeOut", duration: 1 }}
+                        >
+                            {text?.heading &&
+                                <h2 className="font-stratos font-semibold uppercase text-[40px] md:text-[50px] leading-[0.995] text-rm-white">
+                                    {text.heading}
+                                </h2>
+                            }
+                            {text?.intro &&
+                                <p
+                                    dangerouslySetInnerHTML={{ __html: Parser(text.intro) }}
+                                    className="font-basic-sans font-light text-[26px] md:text-[34px] leading-[1.15] text-rm-white"
+                                />
+                            }
+                            {text?.body &&
+                                <p
+                                    dangerouslySetInnerHTML={{ __html: Parser(text.body) }}
+                                    className="font-basic-sans font-light text-[21px] leading-[28px] text-rm-white"
+                                />
+                            }
+                        </motion.div>
+
+                        <motion.div
+                            className={`w-full xl:w-[408px] ${quoteOnLeft ? 'xl:order-1' : ''}`}
+                            initial={{ x: 0 }}
+                            animate={{ x: 0 }}
+                            transition={{ ease: "easeOut", duration: 1 }}
+                        >
+                            {quoteCard?.quote &&
+                                <div className="bg-rm-carbon rounded-[20px] py-5 px-6 flex flex-col items-center justify-center xl:min-h-[469px]">
+                                    <div className="flex flex-col gap-4 items-center justify-center xl:max-w-[357px]">
+                                        <p className="font-basic-sans font-semibold italic text-[32px] md:text-[43px] leading-[1.2] text-rm-white">
+                                            {quoteCard.quote}
+                                        </p>
+                                        {quoteCard.author &&
+                                            <p className="font-basic-sans font-bold text-[18px] leading-[1.4] text-rm-white mt-4 not-italic">
+                                                {quoteCard.author}
+                                            </p>
+                                        }
+                                        {quoteCard.title &&
+                                            <small className="font-basic-sans text-[14px] leading-[1.4] text-rm-white not-italic">
+                                                {quoteCard.title}
+                                            </small>
+                                        }
+                                    </div>
+                                </div>
+                            }
+                        </motion.div>
+                    </div>
+                }
+            </Container>
+        </Section>
+    )
+}
+
+export default TwoColTextQuoteCard
+
+
+export const query = graphql`
+  fragment TwoColTextQuoteCardPage on WpPage_Flexiblelayouts_Layouts {
+    ... on WpPage_Flexiblelayouts_Layouts_TwoColTextQuoteCard {
+        fieldGroupName
+        layoutTwoColTextQuoteCard {
+          layoutContent {
+            quoteContent {
+                author
+                quote
+                title
+                quotations
+            }
+            quotePosition
+            textContent {
+              body
+              heading
+              intro
+            }
+          }
+          layoutSettings {
+            padding {
+              bottom
+              top
+            }
+            anchorId
+            backgroundColor
+            classes
+            id
+            containerWidth
+          }
+        }
+      }
+  }
+`
+
+export const serviceQuery = graphql`
+  fragment TwoColTextQuoteCardService on WpService_Flexiblelayouts_Layouts {
+    ... on WpService_Flexiblelayouts_Layouts_TwoColTextQuoteCard {
+        fieldGroupName
+        layoutTwoColTextQuoteCard {
+          layoutContent {
+            quoteContent {
+                author
+                quote
+                title
+                quotations
+            }
+            quotePosition
+            textContent {
+              body
+              heading
+              intro
+            }
+          }
+          layoutSettings {
+            padding {
+              bottom
+              top
+            }
+            anchorId
+            backgroundColor
+            classes
+            id
+            containerWidth
+          }
+        }
+      }
+  }
+`
+
+export const projectQuery = graphql`
+  fragment TwoColTextQuoteCardProject on WpProject_Flexiblelayouts_Layouts {
+    ... on WpProject_Flexiblelayouts_Layouts_TwoColTextQuoteCard {
+        fieldGroupName
+        layoutTwoColTextQuoteCard {
+          layoutContent {
+            quoteContent {
+                author
+                quote
+                title
+                quotations
+            }
+            quotePosition
+            textContent {
+              body
+              heading
+              intro
+            }
+          }
+          layoutSettings {
+            padding {
+              bottom
+              top
+            }
+            anchorId
+            backgroundColor
+            classes
+            id
+            containerWidth
+          }
+        }
+      }
+  }
+`

--- a/src/static/theme.js
+++ b/src/static/theme.js
@@ -49,6 +49,11 @@ export const theme = {
 
         GHOST_TRANSPARENT_WHITE:        'GHOST_TRANSPARENT_WHITE text-rm-white border-rm-white bg-transparent hover:bg-white hover:text-black',
 
+        GHOST_GREEN_BLACK_HOVER_DARK:     'GHOST_GREEN_BLACK_HOVER_DARK text-rm-black border-rm-green bg-transparent hover:bg-rm-green hover:text-rm-black ',
+        GHOST_GREEN_BLACK_HOVER_LIGHT:    'GHOST_GREEN_BLACK_HOVER_LIGHT text-rm-black border-rm-green bg-transparent hover:bg-rm-green hover:text-rm-black ',
+        GHOST_GREEN_BLACK_TRANSPARENT:    'GHOST_GREEN_BLACK_TRANSPARENT text-rm-black border-rm-green bg-transparent hover:bg-rm-green hover:text-rm-black ',
+        GHOST_GREEN_BLACK_GREY_HOVER_DARK:'GHOST_GREEN_BLACK_GREY_HOVER_DARK text-rm-black border-rm-green bg-transparent hover:bg-rm-green hover:text-rm-black ',
+
 
     },
     

--- a/src/templates/service.js
+++ b/src/templates/service.js
@@ -112,19 +112,15 @@ const WpService = ({ data }) =>{
           }
           {content.heading.green && content.heading.black && 
             <h2 className={"font-stratos uppercase font-bold text-50px sm:text-60px lg:text-100px leading-[3rem] lg:leading-H1 mb-9"}>
-                <span className="text-rm-green lg:block">
-                  {content.heading.green + " "}
-                </span>
-                <span className="text-rm-black">
-                  {content.heading.black}
-                </span>
+                <span className="text-rm-green lg:block" dangerouslySetInnerHTML={{__html: Parser(`${content.heading.green} `)}} />
+                <span className="text-rm-black" dangerouslySetInnerHTML={{__html: Parser(content.heading.black)}} />
             </h2>
           }
           {content.bodyContent && content.bodyContent.map((key) => {
             if (floatP.length < 1 || key.textSize === "large") {
               const textSize = key.textSize === 'large' ? 'H4_LTE' : 'P_STD';  
               return(
-                    <p dangerouslySetInnerHTML={{__html: Parser(key.body)}} className={theme.text[textSize] + 'mb-9' } key={key.body}></p>
+                  <p dangerouslySetInnerHTML={{__html: Parser(key.body)}} className={theme.text[textSize] + 'mb-9' } key={key.body}></p>
               )
             }
             return (<></>)


### PR DESCRIPTION
Introduce several new flexible layout components (BulletsWithImage, ExpandableIconBoxes, OverlapImageCard, StepsWithCard, StepsWithImages, TwoColTextQuoteCard) and their GraphQL fragments (page/service/project). Register new layouts in layoutIndex and include fragments in FlexibleLayouts queries. Update Parser with new tags ([black], [H1_STD], [H1_LTE]) and add new GHOST_GREEN_* button style variants to theme. Minor fixes: tidy Buttons comment, remove debug console.log in TwoColTextQuote, and update service template to render headings/bodies with Parser via dangerouslySetInnerHTML.