### PR TITLE
Refine stat parsing and nested list styles

### DIFF
--- a/src/components/ResultCard.js
+++ b/src/components/ResultCard.js
@@ -12,8 +12,8 @@ const ResultCard = (props) => {
         ${props.columns === '1' ? 'md:max-w-[60%]' : ''}
         ${props.noBoldDescription ? 'font-normal' : ''}
         `;
-    const statNumber        = content.stat ? content.stat.split(/[^\d.]+/)[0] : false;
-    const suffixString      = content.stat ? content.stat.split(/[\d.]+/)[1] : false;
+    const statNumber        = content.stat ? content.stat.match(/[\d.]+/)?.[0] || false : false;
+    const suffixString      = content.stat ? content.stat.match(/[^\d.]+$/)?.[0] || '' : false;
     const columnsNum        = parseInt(props.columns);
 
     const classes = {
@@ -39,11 +39,12 @@ const ResultCard = (props) => {
                     <Counter number={statNumber} title={suffixString} classes={statClass} columns={columnsNum} />   
                 }
                 {!props.noCounter && content.stat && statNumber < 40 &&
-                    <span className={statClass}>{`${statNumber}${suffixString}`}</span>   
+                    <span className={statClass}>{`${content.stat}`}</span>   
                 }          
                 {props.noCounter && content.stat &&
                     <span className={statClass}>{content.stat}</span>
-                    }   
+                }   
+                
                 {content.description &&  
                    <p dangerouslySetInnerHTML={{__html: Parser(content.description)}} className={`${theme.text.H5 + 'font-basic-sans normal-case'} ${descriptionClass}`}></p>  
                 }

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -184,6 +184,9 @@ input:-internal-autofill-selected, input:-internal-autofill:active, input:-inter
 .blog-container ul {
     @apply list-disc pl-5 mb-10;
 }
+.blog-container ul ul {
+    @apply mb-0
+}
 
 .blog-container ol {
     @apply list-decimal pl-5 mb-10;


### PR DESCRIPTION
Improve numeric/stat parsing and rendering: use regex .match to extract statNumber and trailing suffix safely (with sensible defaults) to avoid split-based edge cases, and render the original content.stat for small values. Minor JSX whitespace cleanup. Add CSS for .blog-container ul ul to remove bottom margin (mb-0) and tighten nested list spacing.