### PR TITLE
Tighten blog layout and fix list styles

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -182,10 +182,11 @@ input:-internal-autofill-selected, input:-internal-autofill:active, input:-inter
 }
 
 .blog-container ul {
-    @apply list-disc pl-5 mb-10;
+    @apply list-disc pl-5 mb-10 ml-6;
 }
 .blog-container ul ul {
-    @apply mb-0
+    @apply mb-0;
+    list-style: circle;
 }
 
 .blog-container ol {

--- a/src/templates/post.js
+++ b/src/templates/post.js
@@ -102,8 +102,8 @@ const WpPost = ({ data, pageContext }) => {
   return (
     <>
       {/* <Seo post={content} /> */}
-      <hgroup className="container pt-20">
-        <h1 className={theme.text.H1_STD + 'mb-9'}> {content.title} </h1>
+      <hgroup className="container pt-12 max-w-[900px]">
+        <h1 className='font-stratos uppercase font-bold text-60px leading-H1-m mb-9'> {content.title} </h1>
         <div className="flex items-center">
           {content.author.node.users.avatar && 
             <GatsbyImage className="w-[70px] h-[70px] mr-5 rounded-full object-center object-cover" image={content.author.node.users.avatar.localFile.childImageSharp.gatsbyImageData} alt={content.author.node.name} />
@@ -112,7 +112,7 @@ const WpPost = ({ data, pageContext }) => {
         </div>
         <GatsbyImage className="w-full mt-9" image={content.featuredImage.node.localFile.childImageSharp.gatsbyImageData} alt={`featured image`} />    
       </hgroup>
-      <article className="container blog-container my-9 font-basic-sans">
+      <article className="container blog-container my-9 font-basic-sans max-w-[900px]">
         <div dangerouslySetInnerHTML={ {__html: Parser(content.content, 'blog')} }></div>
       </article>
       <nav className="container mb-20">


### PR DESCRIPTION
Constrain post content width and adjust heading/styles: set hgroup and article to max-w-[900px], reduce top padding (pt-20 -> pt-12), and replace the themed H1 with explicit utility classes for font, case, weight and size. CSS tweaks: add ml-6 to .blog-container ul, terminate @apply with a semicolon, and set nested ul list-style to circle. These changes standardize spacing and improve nested list appearance.