### PR TITLE
Adjust icon text boxes layout and menu spacing

### DIFF
--- a/src/components/IconTextBoxFlex.js
+++ b/src/components/IconTextBoxFlex.js
@@ -109,7 +109,7 @@ const IconTextBoxFlex = (props) => {
                     <div className={`mb-4`}>
                         <p ref={ref}
                             style={{marginTop: customTop, marginBottom: customBottom, marginLeft: '24px', textTransform: customCase}}
-                            className={ `${headingfont} block items-center ${props.color} w-full` }>
+                            className={ `${headingfont} block items-center ${props.color} break-words` }>
                             { content.heading }
                         </p>
                     </div>

--- a/src/components/global/DesktopMenu.js
+++ b/src/components/global/DesktopMenu.js
@@ -119,7 +119,7 @@ const DesktopMenu = () => {
 
                                                 if(subNavItem.label.toLowerCase() === 'ai search audit') {
                                                     return(
-                                                        <Link key={`level-2b__${uid}__${index}`} to={subNavItem.url} className={`group/link flex text-black hover:text-white focus:text-white bg-rm-pale-grey hover:bg-black focus:bg-black transition-all duration-300 ease-out w-max px-6 -ml-1 py-2 items-center rounded-md`}>
+                                                        <Link key={`level-2b__${uid}__${index}`} to={subNavItem.url} className={`group/link flex text-black hover:text-white focus:text-white bg-rm-pale-grey hover:bg-black focus:bg-black transition-all duration-300 ease-out w-max px-6 -ml-1 py-2 items-center rounded-md -mb-[15px]`}>
                                                             {menuIconHover ? 
                                                                 <>
                                                                     {menuIcon && 

--- a/src/layouts/layouts/IconTextBoxes.js
+++ b/src/layouts/layouts/IconTextBoxes.js
@@ -91,18 +91,17 @@ const IconTextBoxes = (props) => {
           <Container container={settings.containerWidth}>
           <div>
             {content.heading &&
-              <h2 className={`text-center mb-4 ${textColor} ${headingfont}`} dangerouslySetInnerHTML={{__html: Parser(content.heading)}}>
-              </h2>
+              <h2 className={`text-center mb-4 ${textColor} ${headingfont}`} dangerouslySetInnerHTML={{__html: Parser(content.heading)}}/>
             }
-          {content.body &&
-            //testing removal of mb from p below and adding to icon box wrapper class
-            <p dangerouslySetInnerHTML={{__html: Parser(content.body)}} className={`${theme.text.P_STD} max-w-[1120px] mx-auto text-center ${textColor}`}></p>
-          }
-          {content.subheading &&
-          <p className={`mt-10 text-center ${textColor}`}>
-              <span dangerouslySetInnerHTML={{__html: Parser(content.subheading)}} className={theme.text.H4}></span>
-          </p>
-          }
+            {content.body &&
+              //testing removal of mb from p below and adding to icon box wrapper class
+              <p dangerouslySetInnerHTML={{__html: Parser(content.body)}} className={`${theme.text.P_STD} max-w-[1120px] mx-auto text-center ${textColor}`}/>
+            }
+            {content.subheading &&
+              <p className={`mt-10 text-center ${textColor}`}>
+                  <span dangerouslySetInnerHTML={{__html: Parser(content.subheading)}} className={theme.text.H4}></span>
+              </p>
+            }
           </div>
 
           <div ref={iconContainer} className={wrapperClasses}>


### PR DESCRIPTION
Refactor layout and spacing for icon text sections and tweak desktop menu spacing.

- IconTextBoxFlex: replace `w-full` with `break-words` on heading paragraph to allow proper wrapping instead of forcing full-width behavior.
- DesktopMenu: add `-mb-[15px]` to the AI Search Audit submenu link to adjust bottom spacing for that specific item.
- IconTextBoxes: clean up markup by consolidating heading/body/subheading rendering, remove duplicate blocks, and update paragraph classes to centralize spacing and presentation.