### PR TITLE
Add post padding and update Tailwind safelist

### DIFF
--- a/src/templates/post.js
+++ b/src/templates/post.js
@@ -112,7 +112,7 @@ const WpPost = ({ data, pageContext }) => {
         </div>
         <GatsbyImage className="w-full mt-9" image={content.featuredImage.node.localFile.childImageSharp.gatsbyImageData} alt={`featured image`} />    
       </hgroup>
-      <article className="container blog-container my-9 font-basic-sans max-w-[900px]">
+      <article className="container blog-container my-9 font-basic-sans max-w-[900px] px-4">
         <div dangerouslySetInnerHTML={ {__html: Parser(content.content, 'blog')} }></div>
       </article>
       <nav className="container mb-20">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -71,7 +71,12 @@ module.exports = {
     'text-[60px]',
     'opacity-25',
     'lg:max-w-[650px]',
-    'lg:max-w-[640px]'
+    'lg:max-w-[640px]',
+    '!m-0',
+    '!pr-8',
+    '!pb-8',
+    '!pl-12',
+    '!py-12'
   ],
   theme: {
     screens:{


### PR DESCRIPTION
Add horizontal padding (px-4) to the post article container to prevent content from touching the viewport edges. Also add several forced margin/padding utilities ('!m-0', '!pr-8', '!pb-8', '!pl-12', '!py-12') to the Tailwind safelist so those important-variant classes are included in the generated CSS.